### PR TITLE
Disables Tablet Resource Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Just run the new ```importPoEditorStrings``` task via Android Studio or command 
 This task will:
 - download all strings files (every available lang) from PoEditor given the api token and project id.
 - process the incoming strings to fix some PoEditor incompatibilities with Android strings system. 
-- create and save strings.xml files to ```/values-<lang>``` (or ```/values``` in case of the default lang)
+- create and save strings.xml files to ```/values-<lang>``` (or ```/values``` in case of the default lang). It supports
+region specific languages by creating the proper folders (i.e. ```/values-es-rMX```).
 
 Handle Tablet specific strings
 --------
@@ -120,7 +121,6 @@ will become, in values-es/strings.xml
 
 To-Do
 -------
-* Manage language specializations: i.e. values-es-rMX for Mexican.
 * Change placeholder system to avoid using ordinals by taking into account the placeholder value instead.
 
 License

--- a/src/main/groovy/com/bq/gradle/ImportPoEditorStringsTask.groovy
+++ b/src/main/groovy/com/bq/gradle/ImportPoEditorStringsTask.groovy
@@ -100,6 +100,7 @@ class ImportPoEditorStringsTask extends DefaultTask {
             // Build final strings XMLs ready to be written to files
             StringWriter sw = new StringWriter()
             XmlNodePrinter np = new XmlNodePrinter(new PrintWriter(sw))
+            np.setPreserveWhitespace(true)
             np.print(translationFileRecords)
             def curatedStringsXmlText = sw.toString()
             StringWriter tabletSw = new StringWriter()
@@ -107,9 +108,9 @@ class ImportPoEditorStringsTask extends DefaultTask {
             tabletNp.print(tabletRecords)
             def curatedTabletStringsXmlText = tabletSw.toString()
 
+
             // If language folders doesn't exist, create it (both for smartphones and tablets)
             // TODO investigate if we can infer the res folder path instead of passing it using poEditorPlugin.res_dir_path
-
             def valuesModifier = createValuesModifierFromLangCode(it)
             def valuesFolder = valuesModifier != defaultLang ? "values-${valuesModifier}" : "values"
             File stringsFolder = new File("${resDirPath}/${valuesFolder}")

--- a/src/main/groovy/com/bq/gradle/ImportPoEditorStringsTask.groovy
+++ b/src/main/groovy/com/bq/gradle/ImportPoEditorStringsTask.groovy
@@ -110,15 +110,15 @@ class ImportPoEditorStringsTask extends DefaultTask {
             // If language folders doesn't exist, create it (both for smartphones and tablets)
             // TODO investigate if we can infer the res folder path instead of passing it using poEditorPlugin.res_dir_path
 
-            // TODO manage langauge specializations: values-es-rMX for Mexican
-            def valuesFolder = it != defaultLang ? "values-${it}" : "values"
+            def valuesModifier = createValuesModifierFromLangCode(it)
+            def valuesFolder = valuesModifier != defaultLang ? "values-${valuesModifier}" : "values"
             File stringsFolder = new File("${resDirPath}/${valuesFolder}")
             if (!stringsFolder.exists()) {
                 println 'Creating strings folder for new language'
                 def folderCreated = stringsFolder.mkdir()
                 println "Folder created: ${folderCreated}"
             }
-            def tabletValuesFolder = it != defaultLang ? "values-${it}-sw600dp" : "values-sw600dp"
+            def tabletValuesFolder = valuesModifier != defaultLang ? "values-${valuesModifier}-sw600dp" : "values-sw600dp"
             File tabletStringsFolder = new File("${resDirPath}/${tabletValuesFolder}")
             if (!tabletStringsFolder.exists()) {
                 println 'Creating tablet strings folder for new language'
@@ -137,6 +137,20 @@ class ImportPoEditorStringsTask extends DefaultTask {
             new File(tabletStringsFolder, 'strings.xml').withWriter { w ->
                 w << curatedTabletStringsXmlText
             }
+        }
+    }
+
+    /**
+     * Creates values file modifier taking into account specializations (i.e values-es-rMX for Mexican)
+     * @param langCode
+     * @return proper values file modifier (i.e. es-rMX)
+     */
+    String createValuesModifierFromLangCode(String langCode) {
+        if (!langCode.contains("-")) {
+            return langCode
+        } else {
+            String[] langParts = langCode.split("-")
+            return langParts[0] + "-" + "r" + langParts[1].toUpperCase()
         }
     }
 

--- a/src/main/groovy/com/bq/gradle/ImportPoEditorStringsTask.groovy
+++ b/src/main/groovy/com/bq/gradle/ImportPoEditorStringsTask.groovy
@@ -113,31 +113,38 @@ class ImportPoEditorStringsTask extends DefaultTask {
             // TODO investigate if we can infer the res folder path instead of passing it using poEditorPlugin.res_dir_path
             def valuesModifier = createValuesModifierFromLangCode(it)
             def valuesFolder = valuesModifier != defaultLang ? "values-${valuesModifier}" : "values"
-            File stringsFolder = new File("${resDirPath}/${valuesFolder}")
-            if (!stringsFolder.exists()) {
-                println 'Creating strings folder for new language'
-                def folderCreated = stringsFolder.mkdir()
-                println "Folder created: ${folderCreated}"
-            }
-            def tabletValuesFolder = valuesModifier != defaultLang ? "values-${valuesModifier}-sw600dp" : "values-sw600dp"
-            File tabletStringsFolder = new File("${resDirPath}/${tabletValuesFolder}")
-            if (!tabletStringsFolder.exists()) {
-                println 'Creating tablet strings folder for new language'
-                def tabletFolderCreated = tabletStringsFolder.mkdir()
-                println "Folder created: ${tabletFolderCreated}"
+            if(curatedStringsXmlText.length() > 0) {
+                File stringsFolder = new File("${resDirPath}/${valuesFolder}")
+                if (!stringsFolder.exists()) {
+                    println 'Creating strings folder for new language'
+                    def folderCreated = stringsFolder.mkdir()
+                    println "Folder created: ${folderCreated}"
+                }
+                // Write downloaded and post-processed XML to files
+                println "Writing strings.xml file"
+                new File(stringsFolder, 'strings.xml').withWriter { w ->
+                    w << curatedStringsXmlText
+                }
             }
 
-            // TODO delete existing strings.xml files
+           if(project.extensions.poEditorPlugin.generate_tablet_res) {
+                def tabletValuesFolder = valuesModifier != defaultLang ? "values-${valuesModifier}-sw600dp" : "values-sw600dp"
+                File tabletStringsFolder = new File("${resDirPath}/${tabletValuesFolder}")
+                if (!tabletStringsFolder.exists()) {
+                    println 'Creating tablet strings folder for new language'
+                    def tabletFolderCreated = tabletStringsFolder.mkdir()
+                    println "Folder created: ${tabletFolderCreated}"
+                }
 
-            // Write downloaded and post-processed XML to files
-            println "Writing strings.xml file"
-            new File(stringsFolder, 'strings.xml').withWriter { w ->
-                w << curatedStringsXmlText
+                println "Writing tablet strings.xml file"
+                new File(tabletStringsFolder, 'strings.xml').withWriter { w ->
+                    w << curatedTabletStringsXmlText
+                }
+
             }
-            println "Writing tablet strings.xml file"
-            new File(tabletStringsFolder, 'strings.xml').withWriter { w ->
-                w << curatedTabletStringsXmlText
-            }
+
+
+
         }
     }
 

--- a/src/main/groovy/com/bq/gradle/PoEditorPluginExtension.groovy
+++ b/src/main/groovy/com/bq/gradle/PoEditorPluginExtension.groovy
@@ -15,4 +15,6 @@ class PoEditorPluginExtension {
     def String default_lang = "es"
     // Path to res/ directory: i.e. "${project.rootDir}/app/src/main/res"
     def String res_dir_path = ""
+
+    def Boolean generate_tablet_res = false;
 }

--- a/src/main/groovy/com/bq/gradle/PoEditorPluginExtension.groovy
+++ b/src/main/groovy/com/bq/gradle/PoEditorPluginExtension.groovy
@@ -17,4 +17,7 @@ class PoEditorPluginExtension {
     def String res_dir_path = ""
 
     def Boolean generate_tablet_res = false;
+
+    // Downloads complete languages only
+    def Boolean only_download_complete_lang = false
 }

--- a/src/test/groovy/org/gradle/ImportPoEditorStringsTaskTest.groovy
+++ b/src/test/groovy/org/gradle/ImportPoEditorStringsTaskTest.groovy
@@ -141,4 +141,22 @@ class ImportPoEditorStringsTaskTest {
                 '  </string>\n' +
                 ' </resources>'))
     }
+
+    @Test
+    public void testCreateValuesModifierFromLangCodeWithNormalLangCode() throws Exception {
+        Project project = ProjectBuilder.builder().build()
+        def task = project.task('importPoEditorStrings', type: ImportPoEditorStringsTask)
+
+        assertEquals('es',
+                ((ImportPoEditorStringsTask)task).createValuesModifierFromLangCode('es'))
+    }
+
+    @Test
+    public void testCreateValuesModifierFromLangCodeWithSpecializedLangCode() throws Exception {
+        Project project = ProjectBuilder.builder().build()
+        def task = project.task('importPoEditorStrings', type: ImportPoEditorStringsTask)
+
+        assertEquals('es-rMX',
+                ((ImportPoEditorStringsTask)task).createValuesModifierFromLangCode('es-mx'))
+    }
 }

--- a/src/test/groovy/org/gradle/ImportPoEditorStringsTaskTest.groovy
+++ b/src/test/groovy/org/gradle/ImportPoEditorStringsTaskTest.groovy
@@ -106,9 +106,20 @@ class ImportPoEditorStringsTaskTest {
         Project project = ProjectBuilder.builder().build()
         def task = project.task('importPoEditorStrings', type: ImportPoEditorStringsTask)
 
+        print("199%".replaceAll(/%(?![0-9a-z]+(|\\$[a-z]?))/, "%%"))
         // Test HTML tags are fixed
         assertEquals('Hello <b>%1$s</b>.',
                 ((ImportPoEditorStringsTask)task).postProcessIncomingXMLString('Hello &lt;b&gt;{{name}}&lt;/b&gt;.'))
+    }
+
+    @Test
+    public void testPostProcessIncomingXMLStringHTMLWithPrintf() throws Exception {
+        Project project = ProjectBuilder.builder().build()
+        def task = project.task('importPoEditorStrings', type: ImportPoEditorStringsTask)
+
+        // Test HTML tags are fixed
+        assertEquals('Hello <b>%1$s</b>.',
+                ((ImportPoEditorStringsTask)task).postProcessIncomingXMLString('Hello &lt;b&gt;%1$s&lt;/b&gt;.'))
     }
 
     @Test


### PR DESCRIPTION
* Adds in a new field to the gradle plugin, which is called generate_tablet_res.

* Strips the ending \n inside the <string name="..">"My String\n"</string>. This occured inside the XmlNodePrinter object. Updates it to preserve white space

* Adds in check to make sure that the poeditor strings length is greater than 0 before creating a new resource directory.

Cheers!