### PR TITLE
Add proper support for plurals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!--
 ## [Unreleased]
 ### Added
 - No new features!
+### Changed
+- No changed features!
+### Deprecated
+- No deprecated features!
+### Removed
+- No removed features!
+### Fixed
+- No fixed issues!
+### Security
+- No security issues fixed!
+-->
+
+## [Unreleased]
+### Added
+- Add proper support for `plurals`
 ### Changed
 - No changed features!
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ welcome_message: Hey {{user_name}} how are you
 will become, in `strings.xml`
 
 ```xml
-<string name="welcome_message">Hey %1%s how are you</string>
+<string name="welcome_message">Hey %1$s how are you</string>
 ```
 
 If you need more than one placeholder in the same string, you can use ordinals too:
@@ -231,7 +231,7 @@ welcome_message: Hey {1{user_name}} how are you, today offer is {2{current_offer
 will become, `in strings.xml`
 
 ```xml
-<string name="welcome_message">Hey %1%s how are you, today offer is %2%s</string>
+<string name="welcome_message">Hey %1$s how are you, today offer is %2$s</string>
 ```
 
 This way you could change the order of the placeholders depending on the language:
@@ -245,7 +245,7 @@ welcome_message: La oferta del día es {2{current_offer}} para ti, {1{user_name}
 will become, in `values-es/strings.xml`
 
 ```xml
-<string name="welcome_message">La oferta del día es %2%s para ti, %1%s</string>
+<string name="welcome_message">La oferta del día es %2$s para ti, %1$s</string>
 ```
 
 ## iOS alternative


### PR DESCRIPTION
### Github issue
Resolves #15 

### PR's key points
The PR adds proper support for `plurals` resources, that now get split properly to tablet folders if needed.
No need to add extra support for placeholders since they're processed properly. I've reworked the placeholders' replacement a bit to be simpler, though.

As a side note, I fixed some typos here and there.
 
### How to review this PR?
Basically check `XmlPostProcessor.kt` and `XmlPostProcessorTest.kt` to see the changes
 
### Definition of Done
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left