### PR TITLE
 Add support for configuring resource directory path

### DIFF
--- a/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPlugin.kt
@@ -36,17 +36,17 @@ typealias ConfigName = String
  */
 class PoEditorPlugin : Plugin<Project> {
     override fun apply(project: Project) {
+        val mainResourceDirectory = getResourceDirectory(project, "main")
+
         // Add the 'poEditorPlugin' extension object in the project,
         // used to pass parameters to the main PoEditor task
         val mainPoEditorExtension: PoEditorPluginExtension = project.extensions
             .create<PoEditorPluginExtension>(DEFAULT_PLUGIN_NAME).apply {
                 defaultLang.convention("en")
-                defaultResPath.convention(null)
+                defaultResPath.convention(mainResourceDirectory.asFile.absolutePath)
             }
 
         // Create the main PoEditor task, and add it to the project
-        val mainResourceDirectory = getResourceDirectory(project, "main")
-
         project.registerNewTask<ImportPoEditorStringsTask>(
             getPoEditorTaskName(),
             getMainPoEditorDescription(),

--- a/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPlugin.kt
@@ -41,6 +41,7 @@ class PoEditorPlugin : Plugin<Project> {
         val mainPoEditorExtension: PoEditorPluginExtension = project.extensions
             .create<PoEditorPluginExtension>(DEFAULT_PLUGIN_NAME).apply {
                 defaultLang.convention("en")
+                defaultResPath.convention(null)
             }
 
         // Create the main PoEditor task, and add it to the project

--- a/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPluginExtension.kt
@@ -64,7 +64,7 @@ open class PoEditorPluginExtension
      */
     @get:Optional
     @get:Input
-    val defaultResPath: Property<String?> = objects.property(String::class.java)
+    val defaultResPath: Property<String> = objects.property(String::class.java)
 
     /**
      * Sets the PoEditor API token.
@@ -104,5 +104,5 @@ open class PoEditorPluginExtension
      *
      * Gradle Kotlin DSL users must use `defaultResPath.set(value)`.
      */
-    fun setDefaultResPath(value: String?) = defaultResPath.set(value)
+    fun setDefaultResPath(value: String) = defaultResPath.set(value)
 }

--- a/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPluginExtension.kt
@@ -58,6 +58,15 @@ open class PoEditorPluginExtension
     val defaultLang: Property<String> = objects.property(String::class.java)
 
     /**
+     * Default resources path for the module where the strings should be put in.
+     *
+     * Defaults to the module with the `com.android.application` plugin.
+     */
+    @get:Optional
+    @get:Input
+    val defaultResPath: Property<String?> = objects.property(String::class.java)
+
+    /**
      * Sets the PoEditor API token.
      *
      * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
@@ -86,4 +95,14 @@ open class PoEditorPluginExtension
      * Gradle Kotlin DSL users must use `defaultLang.set(value)`.
      */
     fun setDefaultLang(value: String) = defaultLang.set(value)
+
+    /**
+     * Sets the resources directory path for the strings.xml files.
+     *
+     * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
+     * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
+     *
+     * Gradle Kotlin DSL users must use `defaultResPath.set(value)`.
+     */
+    fun setDefaultResPath(value: String?) = defaultResPath.set(value)
 }

--- a/src/main/kotlin/com/bq/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/bq/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -43,11 +43,13 @@ abstract class ImportPoEditorStringsTask @Inject constructor(private val extensi
         val apiToken: String
         val projectId: Int
         val defaultLang: String
+        val defaultResPath: String?
 
         try {
             apiToken = extension.apiToken.get()
             projectId = extension.projectId.get()
             defaultLang = extension.defaultLang.get()
+            defaultResPath = extension.defaultResPath.get()
         } catch (e: Exception) {
             throw IllegalArgumentException(
                 "You don't have the config '${extension.name}' properly set-up in your '$POEDITOR_CONFIG_NAME' block " +
@@ -56,6 +58,6 @@ abstract class ImportPoEditorStringsTask @Inject constructor(private val extensi
         }
 
         PoEditorStringsImporter.importPoEditorStrings(
-            apiToken, projectId, defaultLang, resourceDirectory.asFile.absolutePath)
+            apiToken, projectId, defaultLang, defaultResPath ?: resourceDirectory.asFile.absolutePath)
     }
 }

--- a/src/main/kotlin/com/bq/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/bq/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -43,7 +43,7 @@ abstract class ImportPoEditorStringsTask @Inject constructor(private val extensi
         val apiToken: String
         val projectId: Int
         val defaultLang: String
-        val defaultResPath: String?
+        val defaultResPath: String
 
         try {
             apiToken = extension.apiToken.get()
@@ -58,6 +58,6 @@ abstract class ImportPoEditorStringsTask @Inject constructor(private val extensi
         }
 
         PoEditorStringsImporter.importPoEditorStrings(
-            apiToken, projectId, defaultLang, defaultResPath ?: resourceDirectory.asFile.absolutePath)
+            apiToken, projectId, defaultLang, defaultResPath)
     }
 }


### PR DESCRIPTION
### PR's key points
* through the `poEditor` config block, devs can now provide the path of the module where the strings.xml files should be written
 
### How to review this PR?
 
### Definition of Done
- [ ] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
