### PR TITLE
Add support for library modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
--  Add support for configuring non-standard resource directory path via `defaultResPath`. _Thanks to [@rafid059](https://github.com/rafid059) for the contribution!_
+- Add support for using the plug-in in library modules.
+- Add support for configuring non-standard resource directory path via `defaultResPath`. _Thanks to [@rafid059](https://github.com/rafid059) for the contribution!_
 <details open><summary>Groovy</summary>
 
 ```groovy

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Attribute                     | Description
 ```apiToken```                | PoEditor API Token.
 ```projectId```               | PoEditor project ID.
 ```defaultLang```             | The lang to be used to build default ```strings.xml``` (```/values``` folder)
+```defaultResPath```          | (Since 1.3.0) (Optional) Path where the plug-in should dump strings. Defaults to the module's default (or build variant) `res` path.
 
 After the configuration is done, just run the new ```importPoEditorStrings``` task via Android Studio or command line:
 
@@ -180,6 +181,46 @@ configuration: `importFreePoEditorStrings`, `importPaidPoEditorStrings`, `import
 Now the `importPoEditorStrings` task will import the main strings configured in the `poEditor` block and also the
 strings for each defined flavor or build type.
 
+## Handling library modules
+> Requires version 1.3.0 of the plug-in
+
+You can also apply the plug-in to library modules. Here's an example:
+Apply and configure the plug-in in your app's `build.gradle` file:
+<details open><summary>Groovy</summary>
+
+```groovy
+apply plugin: "com.android.library"
+apply plugin: "com.bq.poeditor"
+
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+}
+```
+
+</details>
+
+<details><summary>Kotlin</summary>
+
+```kt
+plugins {
+    id "com.android.library"
+    id "com.bq.poeditor"
+}
+
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+}
+```
+
+</details>
+
+You can also apply flavor and build type-specific configurations as you would do when setting them up with application modules.
+The plug-in will generate the proper tasks needed to import the strings under your module: `:<your_module>:import<your_flavor_or_build_type_if_any>PoEditorStrings`
+
 
 ## Handling tablet specific strings
 
@@ -254,6 +295,7 @@ If you want a similar solution for your iOS projects, check this out: [poeditor-
 ## Authors & Collaborators
 * **[Iván Martínez](https://github.com/imartinez)** - *Initial work*
 * **[Adrián García](https://github.com/adriangl)** - *Maintainer*
+* **[sonnet](https://github.com/rafid059)** - *Contributor*
 
 ## License
 This project is licensed under the Apache Software License, Version 2.0.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ strings for each defined flavor or build type.
 > Requires version 1.3.0 of the plug-in
 
 You can also apply the plug-in to library modules. Here's an example:
-Apply and configure the plug-in in your app's `build.gradle` file:
+Apply and configure the plug-in in your library's `build.gradle` file:
 <details open><summary>Groovy</summary>
 
 ```groovy

--- a/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPlugin.kt
@@ -74,7 +74,7 @@ class PoEditorPlugin : Plugin<Project> {
 
             if (!projectHasAnyAndroidPlugin) {
                 throw IllegalStateException(
-                    "The Android Application Gradle plug-in or the Android Library Gradle plug-in was not applied. " +
+                    "The Android Application Gradle plug-in or the Android Library Gradle plug-in were not applied. " +
                     "PoEditor plug-in cannot be configured.")
             }
         }

--- a/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/bq/poeditor/gradle/PoEditorPlugin.kt
@@ -17,11 +17,14 @@
 package com.bq.poeditor.gradle
 
 import com.android.build.gradle.AppPlugin
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.bq.poeditor.gradle.ktx.registerNewTask
 import com.bq.poeditor.gradle.tasks.DummyImportPoEditorStringsTask
 import com.bq.poeditor.gradle.tasks.ImportPoEditorStringsTask
 import com.bq.poeditor.gradle.utils.*
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
@@ -53,64 +56,49 @@ class PoEditorPlugin : Plugin<Project> {
             PLUGIN_GROUP,
             arrayOf(mainPoEditorExtension, mainResourceDirectory))
 
+        // Add flavor and build-type configurations if the project has the "com.android.application" plugin
         project.plugins.withType<AppPlugin> {
-            applyInternal(project, mainPoEditorExtension)
+            applyInternalApp(project, mainPoEditorExtension)
+        }
+
+        // Add flavor and build-type configurations if the project has the "com.android.library" plugin
+        project.plugins.withType<LibraryPlugin> {
+            applyInternalLib(project, mainPoEditorExtension)
         }
 
         project.afterEvaluate {
-            if (project.plugins.findPlugin(AppPlugin::class.java) == null) {
+            val projectHasApplicationPlugin = project.plugins.findPlugin(AppPlugin::class.java) != null
+            val projectHasLibraryPlugin = project.plugins.findPlugin(LibraryPlugin::class.java) != null
+
+            val projectHasAnyAndroidPlugin = projectHasApplicationPlugin || projectHasLibraryPlugin
+
+            if (!projectHasAnyAndroidPlugin) {
                 throw IllegalStateException(
-                    "The Android Gradle Plugin was not applied. " +
-                    "PoEditor plugin cannot be configured.")
+                    "The Android Application Gradle plug-in or the Android Library Gradle plug-in was not applied. " +
+                    "PoEditor plug-in cannot be configured.")
             }
         }
     }
 
-    private fun applyInternal(project: Project,
-                              mainPoEditorExtension: PoEditorPluginExtension) {
+    private fun applyInternalApp(project: Project,
+                                 mainExtension: PoEditorPluginExtension) {
         // Add android.poEditorConfig extension container so we can set-up flavors and build types
-        // configurations.
-        val configsPoEditorExtensionContainer = project.container<PoEditorPluginExtension>()
+        // configurations with Android app modules.
+        val configsExtensionContainer = project.container<PoEditorPluginExtension>()
         val androidExtension = project.the<BaseAppModuleExtension>()
-        (androidExtension as ExtensionAware).extensions.add(POEDITOR_CONFIG_NAME, configsPoEditorExtensionContainer)
+        (androidExtension as ExtensionAware).extensions.add(POEDITOR_CONFIG_NAME, configsExtensionContainer)
 
         val configPoEditorTaskProvidersMap: MutableMap<ConfigName, TaskProvider<*>> = mutableMapOf()
 
         // Add tasks for every build variant
         androidExtension.onVariants {
-            val flavors = this.productFlavors.map { it.second }
-            val buildType = this.buildType
-            val configs = (flavors + buildType).filterNotNull().toSet()
+            val configs = getConfigs(this.productFlavors.map { it.second }, this.buildType)
 
-            configs.forEach { configName ->
-                val configTaskName = getPoEditorTaskName(configName)
-
-                // Only create the task if no other task is registered with the same name (would mean it's already
-                // created.
-                project.tasks.findByName(configTaskName) ?: run {
-                    val configResourceDirectory = getResourceDirectory(project, configName)
-                    val configExtension = buildExtensionForConfig(
-                        configName,
-                        configsPoEditorExtensionContainer,
-                        mainPoEditorExtension)
-
-                    val newConfigPoEditorTask = if (configExtension != null) {
-                        project.registerNewTask<ImportPoEditorStringsTask>(
-                            getPoEditorTaskName(configName),
-                            getMainPoEditorDescription(),
-                            PLUGIN_GROUP,
-                            arrayOf(configExtension, configResourceDirectory))
-                    } else {
-                        project.registerNewTask<DummyImportPoEditorStringsTask>(
-                            getPoEditorTaskName(configName),
-                            getMainPoEditorDescription(),
-                            PLUGIN_GROUP,
-                            arrayOf(configName))
-                    }
-
-                    configPoEditorTaskProvidersMap.put(configName, newConfigPoEditorTask)
-                }
-            }
+            generatePoEditorTasks(configs,
+                project,
+                configsExtensionContainer,
+                mainExtension,
+                configPoEditorTaskProvidersMap)
         }
 
         project.afterEvaluate {
@@ -120,20 +108,104 @@ class PoEditorPlugin : Plugin<Project> {
                 }
             }
 
-            for (configName in configsPoEditorExtensionContainer.names) {
-                if (configName !in allPossibleConfigNames) {
-                    logger.warn("$TAG: " +
-                                "'$POEDITOR_CONFIG_NAME' object '$configName' " +
-                                "does not match a flavor or build type.")
+            verifyAndLinkTasks(configsExtensionContainer,
+                allPossibleConfigNames,
+                configPoEditorTaskProvidersMap,
+                project)
+        }
+    }
+
+    private fun applyInternalLib(project: Project,
+                                 mainExtension: PoEditorPluginExtension) {
+        // Add android.poEditorConfig extension container so we can set-up flavors and build types
+        // configurations with Android library modules.
+        val configsExtensionContainer = project.container<PoEditorPluginExtension>()
+        val androidExtension = project.the<LibraryExtension>()
+        (androidExtension as ExtensionAware).extensions.add(POEDITOR_CONFIG_NAME, configsExtensionContainer)
+
+        val configPoEditorTaskProvidersMap: MutableMap<ConfigName, TaskProvider<*>> = mutableMapOf()
+
+        // Add tasks for every build variant
+        androidExtension.onVariants {
+            val configs = getConfigs(this.productFlavors.map { it.second }, this.buildType)
+
+            generatePoEditorTasks(configs,
+                project,
+                configsExtensionContainer,
+                mainExtension,
+                configPoEditorTaskProvidersMap)
+        }
+
+        project.afterEvaluate {
+            val allPossibleConfigNames: Set<String> by lazy {
+                androidExtension.libraryVariants.flatMapTo(mutableSetOf()) {
+                    listOf(it.buildType.name) + it.productFlavors.map { it.name }
                 }
             }
 
-            logger.debug("$TAG: Configurations to add: $configPoEditorTaskProvidersMap")
+            verifyAndLinkTasks(configsExtensionContainer,
+                allPossibleConfigNames,
+                configPoEditorTaskProvidersMap,
+                project)
+        }
+    }
 
-            // Link all other tasks to main task so they also get executed when executing the main one
-            configPoEditorTaskProvidersMap.values.forEach { task ->
-                project.tasks.named(getPoEditorTaskName()) { dependsOn(task) }
+    private fun getConfigs(productFlavors: List<String>,
+                           buildType: String?): Set<String> = (productFlavors + buildType).filterNotNull().toSet()
+
+    private fun generatePoEditorTasks(configs: Set<String>,
+                                      project: Project,
+                                      configsExtensionContainer: NamedDomainObjectContainer<PoEditorPluginExtension>,
+                                      mainExtension: PoEditorPluginExtension,
+                                      configPoEditorTaskProvidersMap: MutableMap<ConfigName, TaskProvider<*>>) {
+        configs.forEach { configName ->
+            val configTaskName = getPoEditorTaskName(configName)
+
+            // Only create the task if no other task is registered with the same name (would mean it's already
+            // created.
+            project.tasks.findByName(configTaskName) ?: run {
+                val configResourceDirectory = getResourceDirectory(project, configName)
+                val configExtension = buildExtensionForConfig(
+                    configName,
+                    configsExtensionContainer,
+                    mainExtension)
+
+                val newConfigPoEditorTask = if (configExtension != null) {
+                    project.registerNewTask<ImportPoEditorStringsTask>(
+                        getPoEditorTaskName(configName),
+                        getMainPoEditorDescription(),
+                        PLUGIN_GROUP,
+                        arrayOf(configExtension, configResourceDirectory))
+                } else {
+                    project.registerNewTask<DummyImportPoEditorStringsTask>(
+                        getPoEditorTaskName(configName),
+                        getMainPoEditorDescription(),
+                        PLUGIN_GROUP,
+                        arrayOf(configName))
+                }
+
+                configPoEditorTaskProvidersMap.put(configName, newConfigPoEditorTask)
             }
+        }
+    }
+
+    private fun verifyAndLinkTasks(configsExtensionContainer: NamedDomainObjectContainer<PoEditorPluginExtension>,
+                                   allPossibleConfigNames: Set<String>,
+                                   configPoEditorTaskProvidersMap: MutableMap<ConfigName, TaskProvider<*>>,
+                                   project: Project) {
+        for (configName in configsExtensionContainer.names) {
+            if (configName !in allPossibleConfigNames) {
+                logger.warn("$TAG: " +
+                            "'$POEDITOR_CONFIG_NAME' object '$configName' " +
+                            "does not match a flavor or build type.")
+            }
+        }
+
+        logger.debug("$TAG: Configurations to add: $configPoEditorTaskProvidersMap")
+
+        // Link all other tasks to main task so they also get executed when executing the main one
+        configPoEditorTaskProvidersMap.values.forEach { task ->
+            project.tasks.named(getPoEditorTaskName()) { dependsOn(task) }
         }
     }
 


### PR DESCRIPTION
### GitHub issue
Resolves #18 

### PR's key points
The PR adds support for using the plug-in in library modules. The syntax is the same as when using it in application modules, so you'll get your tasks defined under `:<your_module>:import<flavor_or_build_type_if_added>PoEditorStrings`.

I also updated the CHANGELOG and README with the latest changes.
 
### How to review this PR?
Basically take a look to `PoEditorPlugin` to see how we create the extensions for library modules: It's essentially the same as what we do with application modules but changing some variable names.
 
### Definition of Done
- [x] Tests added (if new code is added) -> No tests to add for now, I've got to check if we can test tasks' generation
- [x] There is no outcommented or debug code left
