### PR TITLE
Fix percent symbols being escaped when variables are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - No removed features!
 ### Fixed
-- No fixed issues!
+- Fix percent symbols being escaped when variables are present.
 ### Security
 - No security issues fixed!
 

--- a/src/test/kotlin/com/bq/poeditor/gradle/xml/XmlPostProcessorTest.kt
+++ b/src/test/kotlin/com/bq/poeditor/gradle/xml/XmlPostProcessorTest.kt
@@ -43,8 +43,15 @@ class XmlPostProcessorTest {
     @Test
     fun `Postprocessing percentage symbol in strings works`() {
         // Test % is changed to %%
-        Assert.assertEquals("Hello my friend. I love you 100%%.",
+        Assert.assertEquals("Hello my friend. I love you 100%.",
                 xmlPostProcessor.formatTranslationXml("Hello my friend. I love you 100%."))
+    }
+
+    @Test
+    fun `Postprocessing percentage symbol in text with variables works`() {
+        // Test % is not changed if variables are present
+        Assert.assertEquals("Hello %1\$s. I love you 100%%.",
+            xmlPostProcessor.formatTranslationXml("Hello {{friend}}. I love you 100%."))
     }
 
     @Test


### PR DESCRIPTION
### PR's key points
The PR fixes an issue with percent symbols while post-processing the strings obtained from PoEditor.
It seems that there's a case where percents don't have to be escaped, which is when the text has no variables.

The fix only escapes percent symbols when variables are present in the text, and leave them as is if no variables are present.
 
### How to review this PR?
Just check the change and the test
 
### Definition of Done
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
