### PR TITLE
Add `languages` parameter to filter downloadable languages from PoEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - No security issues fixed!
 
+## [4.3.1] - 2026-02-18
+### Added
+- Add new `languages` parameter to filter which languages to download from PoEditor. If not specified or empty, all languages will be downloaded.
+<details open><summary>Groovy</summary>
+
+```groovy
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    languages = ["en", "es", "fr"] // Download only English, Spanish, and French
+}
+```
+
+</details>
+
+<details><summary>Kotlin</summary>
+
+```kotlin
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    languages.set(listOf("en", "es", "fr")) // Download only English, Spanish, and French
+}
+```
+
+</details>
+
 ## [4.3.0] - 2025-07-14
 ### Added
 - Add new `includeComments` flag to keep comments generated in PoEditor in the generated XML files.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Attribute                              | Description
 ```defaultLang```                      | (Optional) The lang to be used to build default ```strings.xml``` (```/values``` folder). Defaults to English (`en`).
 ```defaultResPath```                   | (Since 1.3.0) (Optional) Path where the plug-in should dump strings. Defaults to the module's default (or build variant) `res` path.
 ```enabled```                          | (Since 1.4.0) (Optional) Enables the generation of the block's related task. Defaults to `true`.
+```languages```                        | (Since 4.3.1) (Optional) List of language codes to download. If empty, all languages will be downloaded. Defaults to empty list.
 ```tags```                             | (Since 2.1.0) (Optional) List of PoEditor tags to download. Defaults to empty list.
 ```languageValuesOverridePathMap```    | (Since 2.2.0) (Optional) Map of `language_code:path` entries that you want to override the default language values folder with. Defaults to empty map.
 ```minimumTranslationPercentage```     | (Since 2.3.0) (Optional) The minimum accepted percentage of translated strings per language. Languages with fewer translated strings will not be fetched. Defaults to no minimum, allowing all languages to be fetched.
@@ -125,7 +126,7 @@ Attribute                              | Description
 ```unquoted```                         | (Since 3.2.0) (Optional) Defines if the strings should be unquoted, overriding default PoEditor configuration. Defaults to `false`.
 ```unescapeHtmlTags```                 | (Since 3.4.0) (Optional) Whether or not to unescape HTML tags (`<`, `>`) from strings. Defaults to `true`.
 ```untranslatableStringsRegex```       | (Since 4.2.0) (Optional) Pattern to use to mark strings as translatable=false in the strings file. Defaults to `null`.
-```includeComments```                  | (Since 5.0.0) (Optional) Whether to include comments from the downloaded strings. Defaults to `true`.
+```includeComments```                  | (Since 4.3.0) (Optional) Whether to include comments from the downloaded strings. Defaults to `true`.
 
 After the configuration is done, just run the new ```importPoEditorStrings``` task via Android Studio or command line:
 
@@ -517,12 +518,42 @@ poEditor {
 </details>
 
 
+## Selecting specific languages to download
+> Requires version 4.3.1 of the plug-in
+
+You can specify which languages to download from PoEditor using the `languages` parameter. If not specified or left empty, all available languages in the project will be downloaded.
+
+<details open><summary>Groovy</summary>
+
+```groovy
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    languages = ["en", "es", "fr"] // Download only English, Spanish, and French
+}
+```
+
+</details>
+
+<details><summary>Kotlin</summary>
+
+```kotlin
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    languages.set(listOf("en", "es", "fr")) // Download only English, Spanish, and French
+}
+```
+
+</details>
 ## Handling filters
 > Requires version 2.4.0 of the plug-in
 
-The plug-in also allows setting filters for narrowing down the type of terms to be downloaded. 
-Supported filters are defined by the POEditor API and currently include:  `translated`, `untranslated`, `fuzzy`, `not_fuzzy`, `automatic`, `not_automatic`, `proofread`, `not_proofread`. 
-At the moment it's not possible to set different filters per language.  
+The plug-in also allows setting filters for narrowing down the type of terms to be downloaded.
+Supported filters are defined by the POEditor API and currently include:  `translated`, `untranslated`, `fuzzy`, `not_fuzzy`, `automatic`, `not_automatic`, `proofread`, `not_proofread`.
+At the moment it's not possible to set different filters for keys per language.
 This is set-up with the optional `filters` parameter in your `poEditor` or `poEditorConfig` blocks:
 
 <details open><summary>Groovy</summary>

--- a/README.md
+++ b/README.md
@@ -548,6 +548,8 @@ poEditor {
 ```
 
 </details>
+
+
 ## Handling filters
 > Requires version 2.4.0 of the plug-in
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/DefaultValues.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/DefaultValues.kt
@@ -27,6 +27,7 @@ object DefaultValues {
     internal val ENABLED = true
     internal val MAIN_CONFIG_NAME: ConfigName = "main"
     internal val DEFAULT_LANG = "en"
+    internal val LANGUAGES = emptyList<String>()
     internal val FILTERS = emptyList<String>()
     internal val ORDER_TYPE = OrderType.NONE.name.lowercase()
     internal val TAGS = emptyList<String>()
@@ -45,6 +46,7 @@ object DefaultValues {
             enabled.convention(ENABLED)
             defaultResPath.convention(resourceDirectory.absolutePath)
             defaultLang.convention(DEFAULT_LANG)
+            languages.convention(LANGUAGES)
             filters.convention(FILTERS)
             order.convention(ORDER_TYPE)
             tags.convention(TAGS)

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
@@ -36,6 +36,15 @@ fun main() {
     val resFileName = dotenv.get("RES_FILE_NAME", "strings")
     val resDirPath = dotenv.get("RES_DIR_PATH", "")
     val defaultLanguage = dotenv.get("DEFAULT_LANGUAGE", "")
+    val languages = dotenv.get("SELECTED_LANGUAGES", "")
+                        .takeIf { it.isNotBlank() }
+                        ?.split(",")
+                        ?.map { it.trim() }
+                    ?: emptyList()
+
+    println("DEBUG: SELECTED_LANGUAGES from .env: '${dotenv.get("SELECTED_LANGUAGES", "")}'")
+    println("DEBUG: Parsed languages: $languages (isEmpty: ${languages.isEmpty()})")
+
     val filters = dotenv.get("FILTERS", "")
                       .takeIf { it.isNotBlank() }
                       ?.split(",")
@@ -66,6 +75,7 @@ fun main() {
         apiToken,
         projectId,
         defaultLanguage,
+        languages,
         resDirPath,
         filters,
         order,

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
@@ -88,6 +88,15 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
     val resFileName: Property<String> = objects.property(String::class.java)
 
     /**
+     * List of language codes to download. If empty, all languages will be downloaded.
+     *
+     * Defaults to an empty list if not present.
+     */
+    @get:Optional
+    @get:Input
+    val languages: ListProperty<String> = objects.listProperty(String::class.java)
+
+    /**
      * Filters to limit downloaded strings with, from the officially supported list in PoEditor.
      *
      * Defaults to an empty list of filters if not present.
@@ -228,6 +237,16 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
      * Gradle Kotlin DSL users must use `resFileName.set(value)`.
      */
     fun setResFileName(value: String) = resFileName.set(value)
+
+    /**
+     * Sets the list of language codes to download.
+     *
+     * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
+     * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
+     *
+     * Gradle Kotlin DSL users must use `languages.set(value)`.
+     */
+    fun setLanguages(value: List<String>) = languages.set(value)
 
     /**
      * Sets the filters to limit downloaded strings with, from the officially supported list in PoEditor.

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -88,6 +88,15 @@ abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
     abstract val resFileName: Property<String>
 
     /**
+     * List of language codes to download. If empty, all languages will be downloaded.
+     *
+     * Defaults to an empty list if not present.
+     */
+    @get:Optional
+    @get:Input
+    abstract val languages: ListProperty<String>
+
+    /**
      * Filters to limit downloaded strings with, from the officially supported list in PoEditor.
      *
      * Defaults to an empty list of filters if not present.
@@ -194,6 +203,7 @@ abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
             apiToken = apiToken,
             projectId = projectId,
             defaultLang = defaultLang.getOrElse(DefaultValues.DEFAULT_LANG),
+            languages = languages.getOrElse(DefaultValues.LANGUAGES),
             resDirPath = defaultResPath.getOrElse(getResourceDirectory(
                 project, DefaultValues.MAIN_CONFIG_NAME).absolutePath
             ),
@@ -220,6 +230,7 @@ abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
         this.defaultLang = extension.defaultLang
         this.defaultResPath = extension.defaultResPath
         this.resFileName = extension.resFileName
+        this.languages = extension.languages
         this.filters = extension.filters
         this.order = extension.order
         this.tags = extension.tags


### PR DESCRIPTION
  ### PR's key points
  - Add `languages` parameter to filter downloadable languages from PoEditor
  - If not specified or empty, all available languages will be downloaded
  - Allows selective language downloads (e.g., only English, Spanish, and
  French)

  ### How to review this PR?
  1. Review the implementation of the `languages` parameter in the plugin
  configuration
  2. Check that the parameter correctly filters languages during the
  download process
  3. Verify backward compatibility - when `languages` is empty or not
  specified, all languages should be downloaded
  4. Test with both Groovy and Kotlin DSL configurations
  5. Confirm that the README documentation accurately reflects the new
  feature

  ### Definition of Done
  - [x] Changes summary added to CHANGELOG.md
  - [x] Documentation added to README.md (if a new feature is added)
  - [ ] Tests added (if new code is added)
  - [x] There is no outcommented or debug code left.