### PR TITLE
Add AGP 9 and Gradle 9 configuration cache compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - No new features!
 ### Changed
-- No changed features!
+- Migrate to AGP 9 public DSL types for compatibility with Gradle 9 and AGP 9.
 ### Deprecated
 - No deprecated features!
 ### Removed
 - No removed features!
 ### Fixed
-- No fixed issues!
+- Fix Gradle configuration cache incompatibility in `ImportPoEditorStringsTask`: accessing `Task.project` at execution time is no longer supported with the configuration cache enabled by default in Gradle 9.
 ### Security
 - No security issues fixed!
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It also provides a built-in syntax to handle placeholders to enhance the already
 
 ## Minimum requirements
 * Gradle 8.2 or above
-* Android Gradle Plug-in 8.0 or above
+* Android Gradle Plug-in 9.0 or above
 
 ## Setting Up
 In your main `build.gradle`, add [jitpack.io](https://jitpack.io/) repository in the `buildscript` block and include the plug-in as a dependency:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ retrofit = "2.9.0"
 okhttp = "4.12.0"
 
 [libraries]
-android-buildTools = "com.android.tools.build:gradle:8.1.2"
+android-buildTools = "com.android.tools.build:gradle:9.0.0"
 
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -18,12 +18,12 @@
 
 package com.hyperdevs.poeditor.gradle
 
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.gradle.AppPlugin
-import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.LibraryPlugin
-import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.hyperdevs.poeditor.gradle.extensions.registerNewTask
 import com.hyperdevs.poeditor.gradle.tasks.ImportPoEditorStringsTask
 import com.hyperdevs.poeditor.gradle.utils.*
@@ -81,7 +81,7 @@ class PoEditorPlugin : Plugin<Project> {
         // Add android.poEditorConfig extension container so we can set-up flavors and build types
         // configurations with Android app modules.
         val configsExtensionContainer = project.container<PoEditorPluginExtension>()
-        val androidExtension = project.the<BaseAppModuleExtension>()
+        val androidExtension = project.the<ApplicationExtension>()
         val androidComponentsExtension = project.the<ApplicationAndroidComponentsExtension>()
         (androidExtension as ExtensionAware).extensions.add(POEDITOR_CONFIG_NAME, configsExtensionContainer)
 
@@ -103,9 +103,8 @@ class PoEditorPlugin : Plugin<Project> {
 
         project.afterEvaluate {
             val allPossibleConfigNames: Set<String> by lazy {
-                androidExtension.applicationVariants.flatMapTo(mutableSetOf()) {
-                    listOf(it.buildType.name) + it.productFlavors.map { it.name }
-                }
+                (androidExtension.productFlavors.map { it.name } +
+                 androidExtension.buildTypes.map { it.name }).toSet()
             }
 
             verifyAndLinkTasks(configsExtensionContainer,
@@ -142,9 +141,8 @@ class PoEditorPlugin : Plugin<Project> {
 
         project.afterEvaluate {
             val allPossibleConfigNames: Set<String> by lazy {
-                androidExtension.libraryVariants.flatMapTo(mutableSetOf()) {
-                    listOf(it.buildType.name) + it.productFlavors.map { it.name }
-                }
+                (androidExtension.productFlavors.map { it.name } +
+                 androidExtension.buildTypes.map { it.name }).toSet()
             }
 
             verifyAndLinkTasks(configsExtensionContainer,

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -26,7 +26,6 @@ import com.hyperdevs.poeditor.gradle.network.api.FilterType
 import com.hyperdevs.poeditor.gradle.network.api.OrderType
 import com.hyperdevs.poeditor.gradle.utils.DEFAULT_PLUGIN_NAME
 import com.hyperdevs.poeditor.gradle.utils.POEDITOR_CONFIG_NAME
-import com.hyperdevs.poeditor.gradle.utils.getResourceDirectory
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
@@ -204,9 +203,7 @@ abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
             projectId = projectId,
             defaultLang = defaultLang.getOrElse(DefaultValues.DEFAULT_LANG),
             languages = languages.getOrElse(DefaultValues.LANGUAGES),
-            resDirPath = defaultResPath.getOrElse(getResourceDirectory(
-                project, DefaultValues.MAIN_CONFIG_NAME).absolutePath
-            ),
+            resDirPath = defaultResPath.get(),
             filters = filters.getOrElse(DefaultValues.FILTERS).map { FilterType.from(it) },
             order = OrderType.from(order.getOrElse(DefaultValues.ORDER_TYPE.lowercase())),
             tags = tags.getOrElse(DefaultValues.TAGS),


### PR DESCRIPTION
### Github issue 
Resolves #82 

### PR's key points
- Add AGP 9 compatibility by migrating to public DSL types
-  Fix Gradle configuration cache incompatibility in `ImportPoEditorStringsTask`: replace `defaultResPath.getOrElse(getResourceDirectory(project, …))` with `defaultResPath.get()`, eliminating an illegal `Task.project` access at execution time
 
### How to review this PR?
- Check `ImportPoEditorStringsTask.kt` — the `resDirPath` assignment in `@TaskAction `now calls `.get()` directly since `defaultResPath` always carries a value set at configuration time; the `getResourceDirectory` fallback was dead code that caused the violation
- Check AGP 9 migration changes for use of public DSL types replacing previously deprecated/removed internal ones
- Run `./gradlew build` to confirm compilation and tests pass
- Optionally run `importPoEditorStrings` with` --configuration-cache` enabled to confirm no `Task.project` invocation error

 
 
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Documentation added to README.md (if a new feature is added)
- [ ] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
